### PR TITLE
Fixed executable determination

### DIFF
--- a/src/Service/Compiler/PackagesCompiler.php
+++ b/src/Service/Compiler/PackagesCompiler.php
@@ -125,7 +125,7 @@ class PackagesCompiler
             }
             $files[$file->getRelativePathName()] = [
                 'contents' => $file->getContents(),
-                'executable' => is_executable($recipe->getLocalPath().$file->getRelativePathName()),
+                'executable' => is_executable($file->getPathname()),
             ];
         }
 


### PR DESCRIPTION
Executable bit is always false due to missing directory separator between recipe path and relative filename